### PR TITLE
feat: Add retry mechanism for OpenAI API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Currently, Gemini CLI cannot easily use models other than Gemini. This Python to
 - 📊 **Model Mapping** - Flexible model name mapping configuration
 - 📝 **Detailed Logging** - Configurable access logs and detailed request logs
 - ⚙️ **Configuration Files** - Unified management through JSON configuration files
+- 🔁 **Automatic Retries** - Automatically retries requests on failure
 
 ## 🚀 Quick Start
 
@@ -41,7 +42,7 @@ Currently, Gemini CLI cannot easily use models other than Gemini. This Python to
 ### 2. Install Dependencies
 
 ```bash
-pip install fastapi uvicorn openai
+pip install -r requirements.txt
 ```
 
 ### 3. Configuration File
@@ -168,6 +169,10 @@ curl -X POST http://localhost:8000/v1beta/models/gemini-2.5-pro:generateContent 
     "enable_detailed_logs": false,
     "enable_access_logs": true,
     "log_directory": "logs"
+  },
+  "retry": {
+    "max_retries": 3,
+    "wait_fixed": 2
   }
 }
 ```
@@ -186,6 +191,8 @@ curl -X POST http://localhost:8000/v1beta/models/gemini-2.5-pro:generateContent 
 | `logging.enable_detailed_logs` | Enable detailed request logs | `false` |
 | `logging.enable_access_logs` | Enable access logs | `true` |
 | `logging.log_directory` | Log directory | `logs` |
+| `retry.max_retries` | Maximum number of retries on failure | `3` |
+| `retry.wait_fixed` | Fixed wait time between retries in seconds | `2` |
 
 ## 📊 Supported LLM Services
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -29,6 +29,7 @@
 - 📊 **模型映射** - 灵活的模型名称映射配置
 - 📝 **详细日志** - 可配置的访问日志和详细请求日志
 - ⚙️ **配置文件** - JSON 配置文件统一管理
+- 🔁 **自动重试** - 请求失败时自动重试
 
 ## 🚀 快速开始
 
@@ -40,7 +41,7 @@
 ### 2. 安装依赖
 
 ```bash
-pip install fastapi uvicorn openai
+pip install -r requirements.txt
 ```
 
 ### 3. 配置文件
@@ -167,6 +168,10 @@ curl -X POST http://localhost:8000/v1beta/models/gemini-2.5-pro:generateContent 
     "enable_detailed_logs": false,
     "enable_access_logs": true,
     "log_directory": "logs"
+  },
+  "retry": {
+    "max_retries": 3,
+    "wait_fixed": 2
   }
 }
 ```
@@ -185,6 +190,8 @@ curl -X POST http://localhost:8000/v1beta/models/gemini-2.5-pro:generateContent 
 | `logging.enable_detailed_logs` | 启用详细请求日志 | `false` |
 | `logging.enable_access_logs` | 启用访问日志 | `true` |
 | `logging.log_directory` | 日志目录 | `logs` |
+| `retry.max_retries` | 失败时最大重试次数 | `3` |
+| `retry.wait_fixed` | 每次重试之间的固定等待时间（秒） | `2` |
 
 ## 📊 支持的 LLM 服务
 

--- a/config.json
+++ b/config.json
@@ -1,19 +1,24 @@
 {
-  "openai_api_key": "sk-1234",
-  "openai_base_url": "https://api.moonshot.cn/v1",
-  "model_mapping": {
-    "gemini-2.5-pro": "kimi-k2-0711-preview",
-    "gemini-2.5-flash": "moonshot-v1-auto"
-  },
-  "default_openai_model": "kimi-k2-0711-preview",
-  "server": {
-    "host": "0.0.0.0",
-    "port": 8000,
-    "log_level": "info"
-  },
-  "logging": {
-    "enable_detailed_logs": false,
-    "enable_access_logs": true,
-    "log_directory": "logs"
-  }
+    "openai_api_key": "sk-1234",
+    "openai_base_url": "https://api.moonshot.cn/v1",
+    "model_mapping": {
+        "gemini-2.5-pro": "kimi-k2-0711-preview",
+        "gemini-2.5-flash": "moonshot-v1-auto"
+    },
+    "default_openai_model": "kimi-k2-0711-preview",
+    "server": {
+        "host": "0.0.0.0",
+        "port": 8000,
+        "log_level": "info"
+    },
+    "logging": {
+        "enable_detailed_logs": false,
+        "enable_access_logs": true,
+        "log_directory": "logs"
+    },
+    "retry": {
+        "max_retries": 3,
+        "wait_fixed": 2,
+        "stop_max_attempt_number": 3
+    }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.100.0
 uvicorn[standard]>=0.22.0
 openai>=1.0.0
+tenacity>=8.2.3


### PR DESCRIPTION
This commit introduces a retry mechanism for all calls to the OpenAI API. The retry behavior is configurable via the `config.json` file.

- Added `tenacity` as a dependency.
- Implemented a `_retryable_create` method in `GeminiProxyService` that uses `tenacity` to retry API calls.
- Updated `generate_content` and `stream_generate_content` to use the new retryable method.
- Added a `retry` section to `config.json` to allow you to configure the retry behavior.
- Updated `README.md` and `README_ZH.md` to document the new feature and installation instructions.