### PR TITLE
fix: Remove redundant retry parameter from config

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,7 +18,6 @@
     },
     "retry": {
         "max_retries": 3,
-        "wait_fixed": 2,
-        "stop_max_attempt_number": 3
+        "wait_fixed": 2
     }
 }


### PR DESCRIPTION
This commit removes the `stop_max_attempt_number` parameter from `config.json` as it was redundant. The `max_retries` parameter is already used to control the number of retry attempts.